### PR TITLE
Fix dispose comment and README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,5 +62,5 @@ Distributed under the MIT License. See `LICENSE` for more information.
 
 ## Contact
 For inquiries or feedback:
-- **Email**: [mnsoqar1@gmail.com]
-- **Project Link**: [https://github.com/Mohammad-soqar/localink_sm]
+- **Email**: [mnsoqar1@gmail.com](mailto:mnsoqar1@gmail.com)
+- **Project Link**: <https://github.com/Mohammad-soqar/localink_sm>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -204,10 +204,14 @@ class _HomeState extends State<Home> with WidgetsBindingObserver{
                           borderRadius: BorderRadius.circular(10),
                         ),
                         child: referencePhoto == null
-                            ? const Icon(Icons.add_a_photo,
-                    p            color:
-                                    secondaryColor) // Adjusted for visibility
-                            : Image.memory(referencePhoto!, fit: BoxFit.cover),
+                            ? const Icon(
+                                Icons.add_a_photo,
+                                color: secondaryColor,
+                              ) // Adjusted for visibility
+                            : Image.memory(
+                                referencePhoto!,
+                                fit: BoxFit.cover,
+                              ),
                       ),
                     ),
                   ],

--- a/lib/screens/comment_screen.dart
+++ b/lib/screens/comment_screen.dart
@@ -22,7 +22,6 @@ class _CommentsScreenState extends State<CommentsScreen> {
 
   @override
   void dispose() {
-    // TODO: implement dispose
     super.dispose();
     _commentController.dispose();
   }


### PR DESCRIPTION
## Summary
- fix `dispose` method comment in comment screen
- clean up icon widget syntax in main app
- make contact info clickable in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d796807948328b862f8aa5f4a3eee